### PR TITLE
chore: update project link to resume in ProjectsSection

### DIFF
--- a/src/routes/-components/projects-section.tsx
+++ b/src/routes/-components/projects-section.tsx
@@ -63,7 +63,7 @@ const ProjectsSection = ({ projects = defaultProjects }: ProjectsSectionProps) =
           En savoir plus ?
         </h2>
         <a
-          href="https://drive.google.com/file/d/1sgsltOIyik-MHUHlspih7rs8BqXyb5l2/view?usp=drive_link"
+          href="https://drive.google.com/file/d/1c6Kg974uU0xIYfpInPAUafW7XgiD4JA4/view?usp=sharing"
           target="_blank"
           rel="noopener noreferrer"
           className="border-sarcele-300 hover:bg-sarcele-300/10 relative mt-3 rounded-full border px-8 py-3 shadow-lg transition-all duration-300"


### PR DESCRIPTION
This pull request includes a minor update to the `ProjectsSection` component. The change updates the `href` link for the "En savoir plus ?" section to point to a new Google Drive file.

* [`src/routes/-components/projects-section.tsx`](diffhunk://#diff-008ba5ee336d9eb67ffd9484456096db020fb2a0e520c14a395982a39daf7700L66-R66): Updated the `href` attribute in the `<a>` tag to use a new Google Drive link for the "En savoir plus ?" section.